### PR TITLE
[NOP-36] Deploy - AWS EB deploy 설정 (einaregilsson/beanstalk-deploy 설정 변경)

### DIFF
--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -103,11 +103,11 @@ jobs:
       - name: Deploy to EB
         uses: einaregilsson/beanstalk-deploy@v21
         with:
-          aws_access_key: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws_secret_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws_access_key: ${{ env.AWS_ACCESS_KEY_ID }}
+          aws_secret_key: ${{ env.AWS_SECRET_ACCESS_KEY }}
           aws_session_token: ${{ env.AWS_SESSION_TOKEN }}
           application_name: tmpl-next-ssg
           environment_name: tmpl-next-ssg-env
           version_label: tmpl-next-ssg-${{ steps.define-variables.outputs.INTEGRATED_VERSION }}
-          region: ap-northeast-2
+          region: ${{ secrets.AWS_REGION }}
           deployment_package: deploy/deploy.zip


### PR DESCRIPTION
- `[NOP-36] Deploy - AWS EB deploy 설정 (aws_session_token 설정 추가)` PR([link](https://github.com/dragmove/tmpl-next-ssg/pull/10))의 후속 작업
- Github action `Deploy to EB` step 에서 이슈 발생 ([link](https://github.com/dragmove/tmpl-next-ssg/actions/runs/4733085686/jobs/8400095247))
  - Error: Deployment failed: Error: Status: 403. Code: InvalidClientTokenId, Message: The security token included in the request is invalid
  - 설정 변경
    - `einaregilsson/beanstalk-deploy` github action의 필드 값 변경
    - AWS IAM `github-actions-role`에 `AdministratorAccess-AWSElasticBeanstalk` 권한 정책 추가