### PR TITLE
[NOP-36] Deploy - AWS EB deploy 설정 (wait_for_environment_recovery 설정 추가)

### DIFF
--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -111,3 +111,4 @@ jobs:
           version_label: tmpl-next-ssg-${{ steps.define-variables.outputs.INTEGRATED_VERSION }}
           region: ${{ secrets.AWS_REGION }}
           deployment_package: deploy/deploy.zip
+          wait_for_environment_recovery: 180

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "license": "MIT",
   "scripts": {
     "dev": "NODE_ENV=development next dev",
-    "build": "NODE_ENV=production yarn build:clean && next build && next export -o build",
+    "build": "yarn build:clean && NODE_ENV=production next build && next export -o build",
     "build:clean": "rimraf .next build",
     "start": "next start",
     "lint": "next lint",


### PR DESCRIPTION
- `[NOP-36] Deploy - AWS EB deploy 설정 (docker image 빌드 설정 변경)` PR([link](https://github.com/dragmove/tmpl-next-ssg/pull/13))의 후속 작업
- Github action `Deploy to EB` step 에서 이슈 발생 ([link](https://github.com/dragmove/tmpl-next-ssg/actions/runs/4734783895/jobs/8404171347))
  - Error: Deployment failed: Error: Environment still has health Red 30 seconds after update finished!
    - Deploy 완료 후, EC2 Rolling update 도중, health check timeout 이슈 발생. Deploy는 정상적으로 완료된 것을 확인했음.
  - 설정 변경 
    - wait_for_environment_recovery 추가